### PR TITLE
[hotfix] Fix NPE on Thread deletion

### DIFF
--- a/src/main/java/panda/reppy/commands/slashcommands/PostQuestion.java
+++ b/src/main/java/panda/reppy/commands/slashcommands/PostQuestion.java
@@ -139,7 +139,6 @@ public class PostQuestion extends BaseCommand {
                     && e.getMessageIdLong() != lastMessage,
             e -> {
                 if (CANCEL_WORDS.contains(e.getMessage().getContentRaw().toLowerCase())) {
-                    thread.delete().queue();
                     current.remove(event.getUser().getId());
                     cleanMessages(event, thread);
                     e.getMessage().delete().queue();

--- a/src/main/java/panda/reppy/util/Bot.java
+++ b/src/main/java/panda/reppy/util/Bot.java
@@ -65,7 +65,7 @@ public class Bot {
             // bandwidth if chunking is disabled.
             .setLargeThreshold(50)
             // Set Activity to display the version.
-            .setActivity(Activity.playing("v0.1.0_alpha"));
+            .setActivity(Activity.playing("v0.1.1_beta"));
     }
 
     private static void initSlashCommands(SlashCommandListener listener) {


### PR DESCRIPTION
## Hotfix
 * Fixes the `NullPointerException` being thrown when a question building thread is deleted.